### PR TITLE
Fix Use Case Card height

### DIFF
--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -24,7 +24,6 @@ const Home: React.FC = () => {
             </Box>
             <Grid container spacing={4}>
                 <Grid item xs={12} md={6}>
-
                     <Button
                         component={RouterLink}
                         fullWidth

--- a/src/pages/UseCaseCard.tsx
+++ b/src/pages/UseCaseCard.tsx
@@ -27,7 +27,7 @@ const UseCaseCard: React.FC<UseCaseCardProps> = ({
     <Card style={{ width: "100%" }}>
       <CardActionArea>
         <CardMedia height="160" component="img" image={image} alt={imageAlt} />
-        <CardContent sx={{ height: "120px" }} className={`usecase usecase-${useCase}`}>
+        <CardContent sx={{ minHeight: "120px" }} className={`usecase usecase-${useCase}`}>
           <Typography gutterBottom variant="h5" color="white" component="div">
             {title}
           </Typography>

--- a/src/pages/UseCaseCard.tsx
+++ b/src/pages/UseCaseCard.tsx
@@ -27,7 +27,7 @@ const UseCaseCard: React.FC<UseCaseCardProps> = ({
     <Card style={{ width: "100%" }}>
       <CardActionArea>
         <CardMedia height="160" component="img" image={image} alt={imageAlt} />
-        <CardContent className={`usecase usecase-${useCase}`}>
+        <CardContent sx={{ height: "120px" }} className={`usecase usecase-${useCase}`}>
           <Typography gutterBottom variant="h5" color="white" component="div">
             {title}
           </Typography>


### PR DESCRIPTION
The `minHeight` of the Use Case cards is now fixed to have a more uniform look & feel.

## Before

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/12324017/163167069-4638e0e2-af99-4395-9289-6dc50d5ba56e.png">

## After

<img width="1342" alt="image" src="https://user-images.githubusercontent.com/12324017/163167152-4e6f9213-0af1-49cc-ae18-23cea31a590c.png">

